### PR TITLE
Fix Electron deployment with @builder.io/gpt-crawler

### DIFF
--- a/.erb/configs/webpack.config.base.ts
+++ b/.erb/configs/webpack.config.base.ts
@@ -54,6 +54,12 @@ const configuration: webpack.Configuration = {
       NODE_ENV: 'production',
     }),
   ],
+
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    },
+  },
 };
 
 export default configuration;

--- a/.erb/configs/webpack.config.main.dev.ts
+++ b/.erb/configs/webpack.config.main.dev.ts
@@ -47,6 +47,12 @@ const configuration: webpack.Configuration = {
     new webpack.DefinePlugin({
       'process.type': '"browser"',
     }),
+
+    new webpack.EnvironmentPlugin({
+      NODE_ENV: 'development',
+      DEBUG_PROD: false,
+      START_MINIMIZED: false,
+    }),
   ],
 
   /**

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "main": "./.erb/dll/main.bundle.dev.js",
   "scripts": {
-  "build": "concurrently \"npm run build:main\" \"npm run build:renderer\"",
+  "build": "concurrently \"npm run build:main\" \"npm run build:renderer\" \"npm run build:dll\"",
   "build:dll": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.dev.dll.ts",
   "build:main": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.main.prod.ts",
   "build:renderer": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.prod.ts",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5,8 +5,8 @@ import log from 'electron-log';
 import MenuBuilder from './menu';
 import { resolveHtmlPath } from './util';
 
-// Import the crawler module
-const { startCrawl } = require('./crawler');
+// Import the crawler module using import syntax
+import { startCrawl } from './crawler';
 
 class AppUpdater {
   constructor() {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,3 @@
-// src/main/preload.ts
-
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 
 // Define Channels as a constant array (runtime value)


### PR DESCRIPTION
Update the project to effectively deploy with Electron as a DMG without creating multiple directories and follow Electron.js best practices.

* **package.json**
  - Update the `build` script to include `npm run build:dll`.

* **src/main/main.ts**
  - Import `@builder.io/gpt-crawler` using `import` syntax.

* **.erb/configs/webpack.config.base.ts**
  - Add optimization for splitChunks.

* **.erb/configs/webpack.config.main.dev.ts**
  - Add new webpack.EnvironmentPlugin for development environment.

* **src/main/preload.ts**
  - Remove unnecessary comments.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bbarclay/ChatScrape?shareId=14406580-73f3-413c-82bb-3ffb12778032).