### PR TITLE
Fix crawler integration in standalone application

### DIFF
--- a/src/main/crawler.js
+++ b/src/main/crawler.js
@@ -1,4 +1,4 @@
-const { exec } = require('child_process');
+const { crawl } = require('@builder.io/gpt-crawler');
 const fs = require('fs');
 const path = require('path');
 
@@ -11,9 +11,9 @@ const path = require('path');
  * @param {number} config.maxPagesToCrawl - Maximum pages to crawl.
  * @param {string} config.outputDir - Output directory path.
  * @param {string} config.outputFileName - Base output file name.
- * @returns {ChildProcess|null} - The spawned child process or null if an error occurred.
+ * @returns {Promise<void>} - A promise that resolves when the crawl is complete.
  */
-function startCrawl(config) {
+async function startCrawl(config) {
   // Generate a unique directory name based on timestamp
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   const crawlDir = path.join(config.outputDir, `crawl-${timestamp}`);
@@ -25,80 +25,36 @@ function startCrawl(config) {
     }
   } catch (err) {
     console.error('Error creating directory:', crawlDir, err);
-    return null; // Fail early if we can't create the directory
+    throw err; // Fail early if we can't create the directory
   }
 
   // Print the working directory for debugging
   console.log('Current working directory:', process.cwd());
   console.log('Crawl output directory:', crawlDir);
 
-  // Construct the npx command with required options
-  const command = `npx @builder.io/gpt-crawler \
-    --url "${config.url}" \
-    --match "${config.match}" \
-    --selector "${config.selector}" \
-    --maxPagesToCrawl ${config.maxPagesToCrawl} \
-    --outputFileName "${path.join(crawlDir, config.outputFileName)}"`;
-
-  console.log('Starting the crawl with command:', command);
-
-  // Use process.cwd() instead of __dirname to avoid ENOTDIR error
-  const child = exec(command, { cwd: process.cwd() }, (error, stdout, stderr) => {
-    if (error) {
-      console.error(`Error executing the crawl command: ${error.message}`);
-      console.log('Retrying...');
-      startCrawl(config); // Retry logic: call startCrawl again
-      return;
-    }
-  });
-
-  // Timeout to kill the process if it takes too long
-  const crawlTimeout = setTimeout(() => {
-    console.log('Crawl process taking too long. Terminating...');
-    child.kill();
-  }, 60000); // 60 seconds timeout
-
-  // Handle process stdout
-  child.stdout.on('data', (data) => {
-    console.log(`Crawl STDOUT: ${data}`);
-  });
-
-  // Handle process stderr
-  child.stderr.on('data', (data) => {
-    console.error(`Crawl STDERR: ${data}`);
-  });
-
-  // Handle process exit
-  child.on('exit', (code) => {
-    console.log(`Crawl process exited with code ${code}`);
-    clearTimeout(crawlTimeout);
-
-    if (code !== 0) {
-      console.error(`Crawl failed with exit code ${code}. Retrying...`);
-      startCrawl(config); // Retry logic: retry if the exit code is non-zero
-      return;
-    }
+  try {
+    // Start the crawl
+    await crawl({
+      url: config.url,
+      match: config.match,
+      selector: config.selector,
+      maxPagesToCrawl: config.maxPagesToCrawl,
+      outputFileName: path.join(crawlDir, config.outputFileName),
+    });
 
     // Process output files if needed
-    try {
-      const files = fs.readdirSync(crawlDir).filter((file) => file.startsWith('output'));
-      files.forEach((file, index) => {
-        const newFileName = `output_${index + 1}.json`;
-        fs.renameSync(path.join(crawlDir, file), path.join(crawlDir, newFileName));
-        console.log(`Renamed ${file} to ${newFileName}`);
-      });
-    } catch (error) {
-      console.error('Error processing output files:', error);
-    }
-  });
+    const files = fs.readdirSync(crawlDir).filter((file) => file.startsWith('output'));
+    files.forEach((file, index) => {
+      const newFileName = `output_${index + 1}.json`;
+      fs.renameSync(path.join(crawlDir, file), path.join(crawlDir, newFileName));
+      console.log(`Renamed ${file} to ${newFileName}`);
+    });
 
-  // Handle process close event
-  child.on('close', (code) => {
-    console.log(`Crawl process closed with code ${code}`);
-    clearTimeout(crawlTimeout);
-  });
-
-  return child;
+    console.log('Crawl completed successfully.');
+  } catch (error) {
+    console.error('Error during crawl:', error);
+    throw error;
+  }
 }
 
 module.exports = { startCrawl };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -53,53 +53,7 @@ ipcMain.handle('start-crawl', async (event, config) => {
 
   try {
     // Start the crawler process
-    crawlProcess = startCrawl(config);
-
-    if (!crawlProcess) {
-      event.sender.send('crawl-status', 'Failed to start crawl.');
-      return;
-    }
-
-    // Listen to stdout and stderr from the crawler process
-    crawlProcess.stdout.on('data', (data: string) => {
-      event.sender.send('crawl-output', data);
-    });
-
-    crawlProcess.stderr.on('data', (data: string) => {
-      event.sender.send('crawl-output', `Error: ${data}`);
-    });
-
-    crawlProcess.on('error', (error: Error) => {
-      event.sender.send(
-        'crawl-status',
-        `Crawl encountered an error: ${error.message}`
-      );
-      log.error('Crawl process error:', error);
-      crawlProcess = null;
-    });
-
-    crawlProcess.on('exit', (code: number) => {
-      if (code === 0) {
-        event.sender.send('crawl-status', 'Crawl completed successfully.');
-      } else {
-        event.sender.send('crawl-status', `Crawl exited with code ${code}.`);
-      }
-      log.info(`Crawl process exited with code ${code}`);
-      crawlProcess = null;
-    });
-
-    crawlProcess.on('close', (code: number) => {
-      if (code === 0) {
-        event.sender.send('crawl-status', 'Crawl process closed successfully.');
-      } else {
-        event.sender.send(
-          'crawl-status',
-          `Crawl process closed with code ${code}.`
-        );
-      }
-      log.info(`Crawl process closed with code ${code}`);
-      crawlProcess = null;
-    });
+    await startCrawl(config);
 
     event.sender.send('crawl-status', 'Crawl started successfully.');
     log.info('Crawl started successfully.');


### PR DESCRIPTION
Update `src/main/crawler.js` and `src/main/main.ts` to use `@builder.io/gpt-crawler` module directly instead of `npx`.

* **Crawler.js Changes:**
  - Replace `npx` command with direct usage of `@builder.io/gpt-crawler` module.
  - Remove child process handling and related error handling.
  - Add async/await for starting the crawl.
  - Ensure no multiple files with `crawler-date` are created.

* **Main.ts Changes:**
  - Remove child process handling for the crawler.
  - Use async/await to start the crawl directly.
  - Simplify event handling for crawl status.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bbarclay/ChatScrape?shareId=cb0977e1-918c-497e-8301-5cd949c1fce1).