### PR TITLE
Fix module not found error for @builder.io/gpt-crawler

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     }
   },
   "dependencies": {
-    "@builder.io/gpt-crawler": "^1.5.0",
     "@electron/notarize": "^2.3.2",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-brands-svg-icons": "^6.6.0",
@@ -118,6 +117,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@builder.io/gpt-crawler": "^1.5.0",
     "@electron/rebuild": "^3.3.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
     "@svgr/webpack": "^8.1.0",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -15,7 +15,9 @@
     "link-modules": "node -r ts-node/register ../../.erb/scripts/link-modules.ts"
   },
   "dependencies": {
-    "@builder.io/gpt-crawler": "^1.5.0",
     "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@builder.io/gpt-crawler": "^1.5.0"
   }
 }

--- a/src/main/crawler.js
+++ b/src/main/crawler.js
@@ -1,6 +1,6 @@
-const { crawl } = require('@builder.io/gpt-crawler');
-const fs = require('fs');
-const path = require('path');
+import { crawl } from '@builder.io/gpt-crawler';
+import fs from 'fs';
+import path from 'path';
 
 /**
  * Executes the crawler with the provided configuration.
@@ -57,4 +57,4 @@ async function startCrawl(config) {
   }
 }
 
-module.exports = { startCrawl };
+export { startCrawl };


### PR DESCRIPTION
Fix the module loading error for `@builder.io/gpt-crawler`.

* **Update `package.json`**
  - Remove `@builder.io/gpt-crawler` from `dependencies`.
  - Add `@builder.io/gpt-crawler` to `devDependencies`.

* **Update `release/app/package.json`**
  - Remove `@builder.io/gpt-crawler` from `dependencies`.
  - Add `@builder.io/gpt-crawler` to `devDependencies`.

* **Update `src/main/crawler.js`**
  - Change `require` to `import` syntax for `@builder.io/gpt-crawler`.
  - Change `require` to `import` syntax for `fs` and `path`.
  - Export `startCrawl` using `export` syntax.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bbarclay/ChatScrape?shareId=8af37a75-be20-49d3-a8d9-199a5545d5f0).